### PR TITLE
fix package.json main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "animated_gif",
   "version": "0.0.3",
   "description": "Javascript library for creating animated GIFs",
-  "main": "index.js",
+  "main": "src/Animated_GIF.js",
   "scripts": {
     "build": "node build.js",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
When Animated_GIF is installed via npm and requiring the package `animated_gif` with Browserify you've got an error because there is no `index.js` file (`main` entry).
